### PR TITLE
Cleaned up context and commands

### DIFF
--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -40,7 +40,7 @@ func executeCli(cli string) []string {
 // Takes a volume name and size. Returns the created volume id.
 // For some reason our test container only recoganizes id and not name for some calls.
 func testCreateVolume(t *testing.T, volName string, size uint64) string {
-	cli := "px create volume --name " + volName + " --size " + strconv.FormatUint(size, 10)
+	cli := "px create volume " + volName + " --size " + strconv.FormatUint(size, 10)
 	lines := executeCli(cli)
 	assert.Equal(t, 2, len(lines), "Output does not match")
 	assert.Contains(t, lines[0], "Volume "+volName+" created with id", "expected message not received")
@@ -91,7 +91,7 @@ func testGetAllVolumes(t *testing.T) ([]string, []string) {
 
 // Deletes specified volume
 func testDeleteVolume(t *testing.T, volName string) {
-	cli := "px delete volume --name " + volName
+	cli := "px delete volume " + volName
 	lines := executeCli(cli)
 	fmt.Println(len(lines), lines)
 }
@@ -99,7 +99,7 @@ func testDeleteVolume(t *testing.T, volName string) {
 // Takes a volume name and snapshot name. Returns the created snapshot's volume id.
 // For some reason our test container only recoganizes id and not name for some calls.
 func testCreateSnapshot(t *testing.T, volId string, snapName string) string {
-	cli := "px create snapshot --name " + snapName + " --volume " + volId
+	cli := fmt.Sprintf("px create volumesnapshot %s %s", volId, snapName)
 	lines := executeCli(cli)
 	assert.Equal(t, 2, len(lines), "Output does not match")
 	assert.Contains(t, lines[0], "Snapshot of "+volId+" created with id", "expected message not received")
@@ -113,7 +113,7 @@ func testCreateSnapshot(t *testing.T, volId string, snapName string) string {
 // Takes a volume name and clone name. Returns the created clone's volume id.
 // For some reason our test container only recoganizes id and not name for some calls.
 func testCreateClone(t *testing.T, volId string, cloneName string) string {
-	cli := "px create clone --name " + cloneName + " --volume " + volId
+	cli := fmt.Sprintf("px create volumeclone %s %s", volId, cloneName)
 	lines := executeCli(cli)
 	assert.Equal(t, 2, len(lines), "Output does not match")
 	assert.Contains(t, lines[0], "Clone of "+volId+" created with id", "expected message not received")

--- a/cmd/contextCurrent.go
+++ b/cmd/contextCurrent.go
@@ -21,34 +21,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// contextGetCmd represents the contextGet command
-var contextListCmd = &cobra.Command{
-	Use:     "list",
-	Aliases: []string{"contexts", "ctx"},
-	Short:   "List all context configurations",
-	Long: `List all context configurations
-px get context`,
-	RunE: contextListExec,
+// contextCurrentCmd represents the contextCurrent command
+var contextCurrentCmd = &cobra.Command{
+	Use:     "current",
+	Aliases: []string{"show", "current-context"},
+	Short:   "Show current context name",
+	RunE:    contextCurrentExec,
 }
 
 func init() {
-	contextCmd.AddCommand(contextListCmd)
+	contextCmd.AddCommand(contextCurrentCmd)
 }
 
-func contextListExec(cmd *cobra.Command, args []string) error {
+func contextCurrentExec(cmd *cobra.Command, args []string) error {
 	contextManager, err := contextconfig.NewContextManager(GetConfigFile())
 	if err != nil {
 		return util.PxErrorMessagef(err, "Failed to get context configuration at location %s",
 			GetConfigFile())
 	}
-	cfg := contextManager.GetAll()
-
-	// add extra information
-	cfg = contextconfig.AddClaimsInfo(cfg)
-	cfg = contextconfig.MarkInvalidTokens(cfg)
-
-	// Print out config
-	util.PrintYaml(cfg)
-
+	pxctx, err := contextManager.GetCurrent()
+	if err != nil {
+		return err
+	}
+	util.Printf("%s\n", pxctx.Name)
 	return nil
 }

--- a/cmd/contextDelete.go
+++ b/cmd/contextDelete.go
@@ -24,8 +24,15 @@ import (
 
 // contextDeleteCmd represents the contextDelete command
 var contextDeleteCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Deletes the given context",
+	Use:     "delete [NAME]",
+	Short:   "Deletes the given context",
+	Example: "$ px context delete mycontext",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("Must supply a name for context")
+		}
+		return nil
+	},
 	Long: `Usage:
 px context delete --name context1
 	`,
@@ -40,12 +47,7 @@ func init() {
 }
 
 func contextDeleteExec(cmd *cobra.Command, args []string) error {
-	var nameToDelete string
-	if s, _ := cmd.Flags().GetString("name"); len(s) != 0 {
-		nameToDelete = s
-	} else {
-		return fmt.Errorf("Must supply a context name to delete")
-	}
+	nameToDelete := args[0]
 
 	contextManager, err := contextconfig.NewContextManager(cfgFile)
 	if err != nil {

--- a/cmd/contextSet.go
+++ b/cmd/contextSet.go
@@ -19,33 +19,32 @@ import (
 	"fmt"
 
 	"github.com/portworx/px/pkg/contextconfig"
+	"github.com/portworx/px/pkg/util"
 	"github.com/spf13/cobra"
 )
 
 // setCurrentContextCmd represents the setCurrentContext command
 var contextSetCmd = &cobra.Command{
-	Use:   "set",
-	Short: "Set the current context configuration",
-	Long:  ``,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return contextSetExec(cmd, args)
+	Use:     "set [NAME]",
+	Aliases: []string{"use"},
+	Example: "$ px context set mynewcontext",
+	Short:   "Set the current context configuration",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("Must supply a name for context")
+		}
+		return nil
 	},
+	Long: ``,
+	RunE: contextSetExec,
 }
 
 func init() {
 	contextCmd.AddCommand(contextSetCmd)
-	contextSetCmd.Flags().String("name", "", "Name of current context to set")
 }
 
 func contextSetExec(cmd *cobra.Command, args []string) error {
-	var name string
-
-	if s, _ := cmd.Flags().GetString("name"); len(s) != 0 {
-		name = s
-	} else {
-		return fmt.Errorf("Must supply a name for the context")
-	}
-
+	name := args[0]
 	contextManager, err := contextconfig.NewContextManager(GetConfigFile())
 	if err != nil {
 		return err
@@ -54,6 +53,8 @@ func contextSetExec(cmd *cobra.Command, args []string) error {
 	if err := contextManager.SetCurrent(name); err != nil {
 		return err
 	}
+
+	util.Printf("%s is now the current context", name)
 
 	return nil
 }

--- a/cmd/createCloudmigration.go
+++ b/cmd/createCloudmigration.go
@@ -40,9 +40,7 @@ var createCloudmigrationCmd = &cobra.Command{
 	Use:   "cloudmigration",
 	Short: "Start a cloud migration",
 	Long:  `TODO Add long description`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return execCreateCloudmigration(cmd, args)
-	},
+	RunE:  createCloudmigrationExec,
 }
 
 func init() {
@@ -54,18 +52,9 @@ func init() {
 	createCloudmigrationCmd.Flags().StringVarP(&ccmOpts.req.ClusterId, "cluster-id", "c", "", "ID of the cluster in which volumes are to be migrated")
 	createCloudmigrationCmd.Flags().StringVarP(&ccmOpts.req.TaskId, "task-id", "t", "", "Unique name assocaiated with this migration for idempotency (optional).")
 	createCloudmigrationCmd.Flags().SortFlags = false
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// createCloudmigrationCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// createCloudmigrationCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
-func execCreateCloudmigration(cmd *cobra.Command, args []string) error {
+func createCloudmigrationExec(cmd *cobra.Command, args []string) error {
 	ctx, conn, err := PxConnectDefault()
 	if err != nil {
 		return err

--- a/cmd/createClusterpair.go
+++ b/cmd/createClusterpair.go
@@ -45,13 +45,12 @@ var createClusterpairCmd = &cobra.Command{
 	Use:     "clusterpair",
 	Aliases: []string{"clusterpairs"},
 	Short:   "Pair this cluster with another Portworx cluster",
+	Example: "$ px create clusterpair TODO ADD EXAMPLEs",
 	Long: `TODO
 
 ADD EXAMPLES
 	`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return createClusterpairExec(cmd, args)
-	},
+	RunE: createClusterpairExec,
 }
 
 func init() {

--- a/cmd/createSnapshot.go
+++ b/cmd/createSnapshot.go
@@ -35,25 +35,23 @@ var (
 
 // createSnapshotCmd represents the createSnapshot command
 var createSnapshotCmd = &cobra.Command{
-	Use:   "snapshot",
+	Use:   "volumesnapshot [VOLUME] [NAME]",
 	Short: "Create a volume snapshot",
-	Long: `Create a snapshot for the specified volume.
-Example: px create snapshot --name mysnap --labels 'color=blue,fabric=wool --volume myvol'
+	Long:  `Create a snapshot for the specified volume`,
+	Example: `$ px create volumesnapshot mysnap --labels color=blue,fabric=wool --volume myvol
 This creates a snapshot named mysnap for the specified volume myvol.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return createSnapshotExec(cmd, args)
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return fmt.Errorf("Must supply the volume to snap and a new name for the snapshot")
+		}
+		return nil
 	},
+	RunE: createSnapshotExec,
 }
 
 func init() {
 	createCmd.AddCommand(createSnapshotCmd)
-
-	createSnapshotCmd.Flags().StringVar(&csOpts.req.Name, "name", "", "Name of snapshot to be created (required)")
-	createSnapshotCmd.Flags().StringVar(&csOpts.req.VolumeId, "volume", "", "Name or id of volume (required)")
 	createSnapshotCmd.Flags().StringVar(&csOpts.labelsAsString, "labels", "", "Comma separated list of labels as key-value pairs: 'k1=v1,k2=v2'")
-	createSnapshotCmd.Flags().SortFlags = false
-
-	// TODO bring the flags from rootCmd
 }
 
 func createSnapshotExec(cmd *cobra.Command, args []string) error {
@@ -62,6 +60,10 @@ func createSnapshotExec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer conn.Close()
+
+	// Get name
+	csOpts.req.VolumeId = args[0]
+	csOpts.req.Name = args[1]
 
 	// Get labels
 	if len(csOpts.labelsAsString) != 0 {

--- a/cmd/createVolume.go
+++ b/cmd/createVolume.go
@@ -40,21 +40,24 @@ var (
 
 // createVolumeCmd represents the createVolume command
 var createVolumeCmd = &cobra.Command{
-	Use:   "volume",
+	Use:   "volume [NAME]",
 	Short: "Create a volume in Portworx",
 
 	// TODO:
-	Long: `TODO
-ADD EXAMPLES HERE.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return createVolumeExec(cmd, args)
+	Example: `$ px create volume myvolume --size=3
+This creates a volume called 'myvolume' of 3Gi.`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("Must supply a name for volume")
+		}
+		return nil
 	},
+	RunE: createVolumeExec,
 }
 
 func init() {
 	createCmd.AddCommand(createVolumeCmd)
 
-	createVolumeCmd.Flags().StringVar(&cvOpts.req.Name, "name", "", "Name of volume (required)")
 	createVolumeCmd.Flags().IntVar(&cvOpts.sizeInGi, "size", 0, "Size in GiB")
 	createVolumeCmd.Flags().Int64Var(&cvOpts.req.Spec.HaLevel, "replicas", 0, "Number of replicas also called HA level [1-3]")
 	createVolumeCmd.Flags().BoolVar(&cvOpts.req.Spec.Shared, "shared", false, "Shared volume")
@@ -72,6 +75,9 @@ func createVolumeExec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer conn.Close()
+
+	// Get name
+	cvOpts.req.Name = args[0]
 
 	// Get labels
 	if len(cvOpts.labelsAsString) != 0 {

--- a/cmd/getNodes.go
+++ b/cmd/getNodes.go
@@ -29,9 +29,7 @@ var getNodesCmd = &cobra.Command{
 	Use:     "node",
 	Aliases: []string{"nodes"},
 	Short:   "Get Portworx node information",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return getNodesExec(cmd, args)
-	},
+	RunE:    getNodesExec,
 }
 
 func init() {

--- a/cmd/getPvc.go
+++ b/cmd/getPvc.go
@@ -32,11 +32,10 @@ import (
 
 // getPvcCmd represents the getPvc command
 var getPvcCmd = &cobra.Command{
-	Use:   "pvc",
-	Short: "Show Portworx volume information for Kuberntes PVCs",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return getPvcExec(cmd, args)
-	},
+	Use:     "pvc",
+	Aliases: []string{"pvcs"},
+	Short:   "Show Portworx volume information for Kuberntes PVCs",
+	RunE:    getPvcExec,
 }
 
 func init() {

--- a/cmd/getVolumes.go
+++ b/cmd/getVolumes.go
@@ -35,9 +35,7 @@ var getVolumesCmd = &cobra.Command{
 	Use:     "volume",
 	Aliases: []string{"volumes"},
 	Short:   "Get information about Portworx volumes",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return getVolumesExec(cmd, args)
-	},
+	RunE:    getVolumesExec,
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,8 +60,10 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "px",
-	Short: "Portworx command line tool",
+	Use:           "px",
+	Short:         "Portworx command line tool",
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -26,31 +26,14 @@ import (
 
 // statusCmd represents the status command
 var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return statusExec(cmd, args)
-	},
+	Use: "status",
+	// TODO
+	Short: "TODO: this will move to px describe cluster",
+	RunE:  statusExec,
 }
 
 func init() {
 	rootCmd.AddCommand(statusCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// statusCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// statusCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
 func statusExec(cmd *cobra.Command, args []string) error {

--- a/pkg/contextconfig/contextconfig.go
+++ b/pkg/contextconfig/contextconfig.go
@@ -60,6 +60,13 @@ type ContextManager struct {
 	cfg  *ContextConfig
 }
 
+// New returns an empty, unloaded context manager
+func New(configFile string) *ContextManager {
+	return &ContextManager{
+		path: configFile,
+	}
+}
+
 // GetContextManager loads an in memory reference of the Context Configuration file from disk.
 // This reference is the primary object to use when managing the user's context configuration.
 func NewContextManager(configFile string) (*ContextManager, error) {
@@ -82,6 +89,11 @@ func NewContextManager(configFile string) (*ContextManager, error) {
 // Add inserts a given clientContext into cm.cfg.Configurations, and
 // saves the context.
 func (cm *ContextManager) Add(clientContext *ClientContext) error {
+	if cm.cfg == nil {
+		cm.cfg = new(ContextConfig)
+		cm.cfg.Configurations = make([]ClientContext, 0)
+	}
+
 	if cm.cfg.Current == "" {
 		cm.cfg.Current = clientContext.Name
 	}


### PR DESCRIPTION
Added the following:

* `RunE` in the commands now directly points to the function.
* Added `Example:` to some of the commands
* Added `[NAME]` or `[VOLUME]` to the help showing that arguments are required
* Added `Args:` to the commands that needed it to check the parameters
* Changed volume calls to have arguments for the name of the volumes instead of switches
* Fixed issue in the context where it was unable to create a new context from scratch
* Added new `context current` command to show the current context as done in kubectl