### PR TITLE
Unit test context to multiple clusters

### DIFF
--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -25,14 +25,13 @@ import (
 )
 
 func executeCli(cli string) []string {
-	fmt.Println(cli)
 	so, _, r := pxTestSetupCli(cli)
 
 	// Defer to cleanup state
 	defer r()
 
 	// Start the CLI
-	Execute()
+	runPx()
 
 	return strings.Split(so.String(), "\n")
 }
@@ -92,8 +91,7 @@ func testGetAllVolumes(t *testing.T) ([]string, []string) {
 // Deletes specified volume
 func testDeleteVolume(t *testing.T, volName string) {
 	cli := "px delete volume " + volName
-	lines := executeCli(cli)
-	fmt.Println(len(lines), lines)
+	executeCli(cli)
 }
 
 // Takes a volume name and snapshot name. Returns the created snapshot's volume id.
@@ -103,7 +101,6 @@ func testCreateSnapshot(t *testing.T, volId string, snapName string) string {
 	lines := executeCli(cli)
 	assert.Equal(t, 2, len(lines), "Output does not match")
 	assert.Contains(t, lines[0], "Snapshot of "+volId+" created with id", "expected message not received")
-	fmt.Println(lines[0])
 	words := strings.Split(lines[0], " ")
 	assert.Equal(t, len(words), 7, "expected message not received")
 	// The last item in the message is the id
@@ -117,7 +114,6 @@ func testCreateClone(t *testing.T, volId string, cloneName string) string {
 	lines := executeCli(cli)
 	assert.Equal(t, 2, len(lines), "Output does not match")
 	assert.Contains(t, lines[0], "Clone of "+volId+" created with id", "expected message not received")
-	fmt.Println(lines[0])
 	words := strings.Split(lines[0], " ")
 	assert.Equal(t, len(words), 7, "expected message not received")
 	// The last item in the message is the id

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -32,7 +32,8 @@ func TestPxStatus(t *testing.T) {
 	defer r()
 
 	// Start the CLI
-	Execute()
+	err := runPx()
+	assert.NoError(t, err)
 
 	lines := strings.Split(so.String(), "\n")
 	assert.Contains(t, lines, "Cluster ID: mock")

--- a/hack/config.yml
+++ b/hack/config.yml
@@ -1,7 +1,12 @@
-current: test
+current: source
 configurations:
-- context: test
+- context: source
   token: ""
   endpoint: localhost:9920
+  secure: false
+  kubeconfig: ""
+- context: target
+  token: ""
+  endpoint: localhost:9921
   secure: false
   kubeconfig: ""

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-PORT=9920
-DOCKERNAME=pxtester
 MOCKSDKTAG=0.42.14
 
 fail()
@@ -10,17 +8,20 @@ fail()
 	exit 1
 }
 
+# $1 - name
+# $2 - port
 startdocker()
 {
-	docker run --rm --name pxtester -d -p ${PORT}:9100 openstorage/mock-sdk-server:${MOCKSDKTAG} > /dev/null 2>&1
+	docker run --rm --name ${1} -d -p ${2}:9100 openstorage/mock-sdk-server:${MOCKSDKTAG} > /dev/null 2>&1
 	if [ $? -ne 0 ] ; then
 		fail "Failed to start docker"
 	fi
 }
 
+# $1 - name
 stopdocker()
 {
-	docker stop $DOCKERNAME > /dev/null 2>&1
+	docker stop $1 > /dev/null 2>&1
 	if [ $? -ne 0 ] ; then
 		fail "Failed to stop docker"
 	fi
@@ -28,7 +29,8 @@ stopdocker()
 
 ### MAIN ###
 
-startdocker
+startdocker pxutsource 9920
+startdocker pxuttarget 9921
 
 export PXTESTCONFIG=$PWD/hack/config.yml
 
@@ -41,5 +43,6 @@ else
 	result=$?
 fi
 
-stopdocker
+stopdocker pxutsource
+stopdocker pxuttarget
 exit $result

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -21,6 +21,16 @@ import (
 )
 
 // ListContains returns true when string s is found in the list
+func ListContainsSubString(list []string, s string) bool {
+	for _, value := range list {
+		if strings.Contains(value, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// ListContains returns true when string s is found in the list
 func ListContains(list []string, s string) bool {
 	for _, value := range list {
 		if value == s {

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -23,6 +23,49 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestListContainsSubString(t *testing.T) {
+	tests := []struct {
+		list  []string
+		s     string
+		found bool
+	}{
+		{
+			list:  []string{"Hello", "World"},
+			s:     "ell",
+			found: true,
+		},
+		{
+			list:  []string{"Hello", "World"},
+			s:     "nothere",
+			found: false,
+		},
+		{
+			list:  []string{"Hello", "World"},
+			s:     "Hellow",
+			found: false,
+		},
+		{
+			list:  []string{"Hello", "World"},
+			s:     "Hello",
+			found: true,
+		},
+		{
+			list:  []string{},
+			s:     "Hello",
+			found: false,
+		},
+		{
+			list:  []string{},
+			s:     "",
+			found: false,
+		},
+	}
+
+	for _, test := range tests {
+		assert.True(t, test.found == ListContainsSubString(test.list, test.s))
+	}
+}
+
 /*
  To test postivive case of utils.ListContains function.
  Test if given element is present in the list.


### PR DESCRIPTION
This is a unit test for the fix in 0331438

This has the following fixes:

* Unit tests where printing to the screen. Removed printfs
* `cmd/` unit tests should not call `Execute()` since it calls `os.Exit()` on error. Instead `cmd/` unit tests should call now `runPx()`
* Added new function to utils package