### PR TITLE
Removed show-lables, selector and output persistent flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,7 +84,6 @@ func init() {
 	// TODO: move these flags out of persistent
 	rootCmd.PersistentFlags().StringP("output", "o", "", "Output in yaml|json|wide")
 	rootCmd.PersistentFlags().Bool("show-labels", false, "Show labels in the last column of the output")
-	rootCmd.PersistentFlags().StringP("selector", "l", "", "Comma separated label selector of the form 'key=value,key=value'")
 
 	// Global cobra configurations
 	rootCmd.Flags().SortFlags = false


### PR DESCRIPTION
Part of #18 

**What this PR does / why we need it**
This PR removes the persistent flags -l, selector from root.go.

**Which issue(s) this PR fixes**
As part of #18, the following are addressed
- Remove -l, --selector from root persistent flag 

**Developer testing showing px output**
```
Prashanths-MacBook-Pro:px prashanthkumar$ ./px
Portworx command line tool

Usage:
  px [command]

Available Commands:
  context     Manage connections to Portworx and other systems
  create      Create an object in Portworx
  delete      Delete an object in Portworx
  describe    Show detailed information of Portworx resources
  get         Get information from Portworx
  help        Help about any command
  plugin      Display px plugin information
  status      TODO: this will move to px describe cluster
  version     Show px version information

Flags:
      --config string    config file (default is $HOME/.px/config.yml)
      --context string   Force context name for the command
  -h, --help             help for px

Use "px [command] --help" for more information about a command.

```