### PR TITLE
Unit tests to use names instead of volume ids

### DIFF
--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -16,124 +16,179 @@ limitations under the License.
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
-	"math/rand"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	api "github.com/libopenstorage/openstorage-sdk-clients/sdk/golang"
+	"github.com/portworx/px/pkg/tests"
+	"github.com/portworx/px/pkg/util"
+
 	"github.com/stretchr/testify/assert"
 )
 
-func executeCli(cli string) []string {
-	so, _, r := pxTestSetupCli(cli)
+// Returns a buffer for stdout, stderr, and a function.
+// The function should be used as a defer to restore the state
+// See status_test.go for an example
+func pxTestSetupCli(args string) (*bytes.Buffer, *bytes.Buffer, tests.Restorer) {
+	// Save
+	oldargs := os.Args
+	oldStdout := util.Stdout
+	oldStderr := util.Stderr
+	oldcfgFile := cfgFile
+
+	// Create new buffers
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	// Set buffers
+	util.Stdout = stdout
+	util.Stderr = stderr
+	os.Args = strings.Split(args, " ")
+	cfgFile = os.Getenv("PXTESTCONFIG")
+
+	return stdout, stderr, func() {
+		cfgFile = oldcfgFile
+		os.Args = oldargs
+		util.Stdout = oldStdout
+		util.Stderr = oldStderr
+	}
+}
+
+// runPx runs a command saved in os.Args and returns the error if any
+func runPx() error {
+	return rootCmd.Execute()
+}
+
+// genVolName generates a unique name for a volume appended to a prefix
+func genVolName(prefix string) string {
+	return fmt.Sprintf("%s-%v", prefix, time.Now().Unix())
+}
+
+// Execute cli and return the buffers of standard out, standard error,
+// and error.
+// Callers must managage global variables using Patch from pkg/tests
+func executeCliRaw(cli string) (*bytes.Buffer, *bytes.Buffer, error) {
+	so, se, r := pxTestSetupCli(cli)
 
 	// Defer to cleanup state
 	defer r()
 
 	// Start the CLI
-	runPx()
+	err := runPx()
 
-	return strings.Split(so.String(), "\n")
+	return so, se, err
 }
 
-func getRandom() uint64 {
-	rand.Seed(time.Now().UTC().Unix())
-	return rand.Uint64()
+// Execute cli and return string lists of standard out, standard error,
+// and error if any.
+// Callers must managage global variables using Patch from pkg/tests
+func executeCli(cli string) ([]string, []string, error) {
+	so, se, err := executeCliRaw(cli)
+
+	return strings.Split(so.String(), "\n"),
+		strings.Split(se.String(), "\n"),
+		err
 }
 
 // Takes a volume name and size. Returns the created volume id.
 // For some reason our test container only recoganizes id and not name for some calls.
-func testCreateVolume(t *testing.T, volName string, size uint64) string {
+func testCreateVolume(t *testing.T, volName string, size uint64) {
 	cli := "px create volume " + volName + " --size " + strconv.FormatUint(size, 10)
-	lines := executeCli(cli)
-	assert.Equal(t, 1, len(lines), "Output does not match")
-	assert.Contains(t, lines[0], "Volume "+volName+" created with id", "expected message not received")
-	words := strings.Split(lines[0], " ")
-	assert.Equal(t, len(words), 6, "expected message not received")
-	// The last item in the message is the id
-	return words[len(words)-1]
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
+	assert.True(t, util.ListContainsSubString(lines, fmt.Sprintf("Volume %s created with id", volName)))
 }
 
-// Takes a volume id and returns true if the volume is found
-func testGetVolume(t *testing.T, volId string, volName string) bool {
-	cli := "px get volume -o wide " + volId
-	lines := executeCli(cli)
-	if strings.Contains(lines[0], "Error: Failed to get volume: Volume id "+volId+" not found") {
-		return false
-	}
-	w := strings.Split(lines[2], " ")
-	// Remove all blanks
-	words := make([]string, 0, len(w))
-	for _, item := range w {
-		if item != "" {
-			words = append(words, item)
-		}
-	}
-	// Verify the first item is the id of the volume
-	assert.Equal(t, volId, words[0])
-	assert.Equal(t, volName, words[1])
-	return true
+// Takes a volume id assert volume exists
+func testHasVolume(id string) bool {
+	// Get volume information
+	cli := "px get volume " + id
+	_, _, err := executeCli(cli)
+
+	return err == nil
 }
 
-//Returns a list of all volume ids
-func testGetAllVolumes(t *testing.T) ([]string, []string) {
-	cli := "px get volume -o wide"
-	lines := executeCli(cli)
+// Return volume information
+// TODO: If necessary, we can do a `px get volume <id> -o json` then
+//       unmarshal the JSON to appropriate object
+// 		 then return the &api.Volume inside of it.
+func testVolumeInfo(t *testing.T, id string) *api.Volume {
+	cli := fmt.Sprintf("px get volume %s -o json", id)
+	so, _, err := executeCliRaw(cli)
+	assert.NoError(t, err)
+
+	var vols []api.SdkVolumeInspectResponse
+	err = json.Unmarshal([]byte(so.String()), &vols)
+	assert.NoError(t, err)
+	assert.Len(t, vols, 1)
+
+	return vols[0].GetVolume()
+}
+
+// Returns a list of all volume ids
+// TODO: We may need to bring this back to the TestXXX functions
+//       depending on what it does, because the output would be
+//       parse, and as a library function, it may be easier to
+//       get a specific volume.
+func testGetAllVolumes(t *testing.T) []string {
+	cli := "px get volume"
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
 	lines = lines[2:]
-	volIds := make([]string, 0, len(lines))
 	volNames := make([]string, 0, len(lines))
 	for _, l := range lines {
 		if l == "" {
 			continue
 		}
 		x := strings.Split(l, " ")
-		volIds = append(volIds, x[0])
-		volNames = append(volNames, x[1])
+		volNames = append(volNames, x[0])
 	}
-	return volIds, volNames
+	return volNames
 }
 
 // Deletes specified volume
 func testDeleteVolume(t *testing.T, volName string) {
 	cli := "px delete volume " + volName
-	executeCli(cli)
+	_, _, err := executeCli(cli)
+	assert.NoError(t, err)
 }
 
-// Takes a volume name and snapshot name. Returns the created snapshot's volume id.
-// For some reason our test container only recoganizes id and not name for some calls.
-func testCreateSnapshot(t *testing.T, volId string, snapName string) string {
+// Takes a volume name and snapshot name
+func testCreateSnapshot(t *testing.T, volId string, snapName string) {
 	cli := fmt.Sprintf("px create volumesnapshot %s %s", volId, snapName)
-	lines := executeCli(cli)
-	assert.Equal(t, 1, len(lines), "Output does not match")
-	assert.Contains(t, lines[0], "Snapshot of "+volId+" created with id", "expected message not received")
-	words := strings.Split(lines[0], " ")
-	assert.Equal(t, len(words), 7, "expected message not received")
-	// The last item in the message is the id
-	return words[len(words)-1]
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
+	assert.True(t, util.ListContainsSubString(lines, fmt.Sprintf("Snapshot of %s created with id", volId)))
 }
 
-// Takes a volume name and clone name. Returns the created clone's volume id.
-// For some reason our test container only recoganizes id and not name for some calls.
-func testCreateClone(t *testing.T, volId string, cloneName string) string {
+// Takes a volume name and clone name
+func testCreateClone(t *testing.T, volId string, cloneName string) {
 	cli := fmt.Sprintf("px create volumeclone %s %s", volId, cloneName)
-	lines := executeCli(cli)
-	assert.Equal(t, 1, len(lines), "Output does not match")
-	assert.Contains(t, lines[0], "Clone of "+volId+" created with id", "expected message not received")
-	words := strings.Split(lines[0], " ")
-	assert.Equal(t, len(words), 7, "expected message not received")
-	// The last item in the message is the id
-	return words[len(words)-1]
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
+	assert.True(t, util.ListContainsSubString(lines, fmt.Sprintf("Clone of %s created with id", volId)))
 }
 
 // Takes a list of volumes and returns a array of string, one volume description per string
+// TODO This should probably be part of the TestXXX call, and not a library call
 func testDescribeVolumes(t *testing.T, volNames []string) []string {
 	cli := "px describe volume"
 	for _, v := range volNames {
 		cli = fmt.Sprintf("%v %v", cli, v)
 	}
-	lines := executeCli(cli)
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
 	l := strings.Join(lines, "\n")
 	vols := strings.Split(l, "\n\n")
 	return vols

--- a/cmd/createClone_test.go
+++ b/cmd/createClone_test.go
@@ -16,39 +16,30 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/portworx/px/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPxCreateclone(t *testing.T) {
-	r := getRandom()
-	volName := fmt.Sprintf("%v-%v", "testVol", r)
-	cloneName := fmt.Sprintf("%v-%v", "cloneVol", r)
+	volName := genVolName("testVol")
+	cloneName := genVolName("cloneVol")
 
 	// Create Volume
-	volId := testCreateVolume(t, volName, 1)
-
-	// Verify that the volume got created
-	exists := testGetVolume(t, volId, volName)
-	assert.Equal(t, exists, true, "Volume create failed")
+	testCreateVolume(t, volName, 1)
+	assert.True(t, testHasVolume(volName))
 
 	// Create clone
-	cloneId := testCreateClone(t, volId, cloneName)
-
-	//Verify that the clone got created
-	exists = testGetVolume(t, cloneId, cloneName)
+	testCreateClone(t, volName, cloneName)
+	assert.True(t, testHasVolume(cloneName))
 
 	// Delete volume
-	testDeleteVolume(t, volId)
-	vols, _ := testGetAllVolumes(t)
-	assert.Equal(t, util.ListContains(vols, volId), false, "Volume delete failed")
-	assert.Equal(t, util.ListContains(vols, cloneId), true, "Volume delete failed")
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
+	assert.True(t, testHasVolume(cloneName))
 
 	// Delete clone
-	testDeleteVolume(t, cloneId)
-	vols, _ = testGetAllVolumes(t)
-	assert.Equal(t, util.ListContains(vols, cloneId), false, "Volume delete failed")
+	testDeleteVolume(t, cloneName)
+	assert.False(t, testHasVolume(volName))
+	assert.False(t, testHasVolume(cloneName))
 }

--- a/cmd/createSnapshot_test.go
+++ b/cmd/createSnapshot_test.go
@@ -16,39 +16,30 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/portworx/px/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPxCreateSnapshot(t *testing.T) {
-	r := getRandom()
-	volName := fmt.Sprintf("%v-%v", "testVol", r)
-	snapName := fmt.Sprintf("%v-%v", "snapVol", r)
+	volName := genVolName("testVol")
+	snapName := genVolName("snapVol")
 
 	// Create Volume
-	volId := testCreateVolume(t, volName, 1)
-
-	// Verify that the volume got created
-	exists := testGetVolume(t, volId, volName)
-	assert.Equal(t, exists, true, "Volume create failed")
+	testCreateVolume(t, volName, 1)
+	assert.True(t, testHasVolume(volName))
 
 	// Create Snapshot
-	snapId := testCreateSnapshot(t, volId, snapName)
-
-	//Verify that the snapshot got created
-	exists = testGetVolume(t, snapId, snapName)
+	testCreateSnapshot(t, volName, snapName)
+	assert.True(t, testHasVolume(snapName))
 
 	// Delete volume
-	testDeleteVolume(t, volId)
-	vols, _ := testGetAllVolumes(t)
-	assert.Equal(t, util.ListContains(vols, volId), false, "Volume delete failed")
-	assert.Equal(t, util.ListContains(vols, snapId), true, "Volume delete unexpected")
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
+	assert.True(t, testHasVolume(snapName))
 
 	// Delete snapshot
-	testDeleteVolume(t, snapId)
-	vols, _ = testGetAllVolumes(t)
-	assert.Equal(t, util.ListContains(vols, snapId), false, "Volume delete failed")
+	testDeleteVolume(t, snapName)
+	assert.False(t, testHasVolume(volName))
+	assert.False(t, testHasVolume(snapName))
 }

--- a/cmd/deleteVolume_test.go
+++ b/cmd/deleteVolume_test.go
@@ -16,30 +16,23 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/portworx/px/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPxDeleteVolume(t *testing.T) {
-	volName := fmt.Sprintf("%v-%v", "testVol", getRandom())
+	volName := genVolName("testVol")
 
 	// Create Volume
-	volId := testCreateVolume(t, volName, 1)
-
-	// Verify that the volume got created
-	exists := testGetVolume(t, volId, volName)
-	assert.Equal(t, exists, true, "Volume create failed")
+	testCreateVolume(t, volName, 1)
+	assert.True(t, testHasVolume(volName))
 
 	// Delete Volume
-	testDeleteVolume(t, volId)
-
-	// Verify that volume got deleted
-	vols, _ := testGetAllVolumes(t)
-	assert.Equal(t, util.ListContains(vols, volId), false, "Volume delete failed")
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
 
 	// Delete it again to ensure we don't get an error
-	testDeleteVolume(t, volId)
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
 }

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 MOCKSDKTAG=0.42.14
+CONTAINER=quay.io/lpabon/mock-sdk-server
 
 fail()
 {
@@ -12,7 +13,7 @@ fail()
 # $2 - port
 startdocker()
 {
-	docker run --rm --name ${1} -d -p ${2}:9100 openstorage/mock-sdk-server:${MOCKSDKTAG} > /dev/null 2>&1
+	docker run --rm --name ${1} -d -p ${2}:9100 ${CONTAINER} > /dev/null 2>&1
 	if [ $? -ne 0 ] ; then
 		fail "Failed to start docker"
 	fi

--- a/pkg/tests/patch.go
+++ b/pkg/tests/patch.go
@@ -1,0 +1,42 @@
+// From https://gist.github.com/imosquera/6716490#sthash.O4z2aQQp.LUHz2Cbb.dpuf
+
+package tests
+
+import (
+	"reflect"
+)
+
+// Restorer holds a function that can be used
+// to restore some previous state.
+type Restorer func()
+
+// Restore restores some previous state.
+func (r Restorer) Restore() {
+	r()
+}
+
+// Patch sets the value pointed to by the given destination to the given
+// value, and returns a function to restore it to its original value.  The
+// value must be assignable to the element type of the destination.
+//
+// Example:
+// Patching a global variable called `somenum` with a temporary value of 3.
+// In tests we would type the following:
+//
+// defer Patch(somenun, 3).Restore()
+//
+func Patch(dest, value interface{}) Restorer {
+	destv := reflect.ValueOf(dest).Elem()
+	oldv := reflect.New(destv.Type()).Elem()
+	oldv.Set(destv)
+	valuev := reflect.ValueOf(value)
+	if !valuev.IsValid() {
+		// This isn't quite right when the destination type is not
+		// nilable, but it's better than the complex alternative.
+		valuev = reflect.Zero(destv.Type())
+	}
+	destv.Set(valuev)
+	return func() {
+		destv.Set(oldv)
+	}
+}


### PR DESCRIPTION
* Moved test library functions from cmd/root_test.go to cmd/common_test.go
* Added `pkg/tests/patch.go` to allow patching of global variables
* Cleaned up library test functions in cmd/common_test.go to use only name
* Added function `genVolName(prefix string)` to generate strings
* Changed ./hack/test.sh to use temporary mock-sdk-server which supports names as ids
* Added `testVolumeInfo(...)` which returns a volume datastructure using `px` itself.  This is used by the describe volume test to check the parent and can be used by many other tests in the future.
* Added `testHasVolume(...)` to return a true/false depending if the volume is present