### PR TITLE
Rework command initialization

### DIFF
--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -40,7 +40,6 @@ func pxTestSetupCli(args string) (*bytes.Buffer, *bytes.Buffer, tests.Restorer) 
 	oldargs := os.Args
 	oldStdout := util.Stdout
 	oldStderr := util.Stderr
-	oldcfgFile := cfgFile
 
 	// Create new buffers
 	stdout := new(bytes.Buffer)
@@ -50,10 +49,8 @@ func pxTestSetupCli(args string) (*bytes.Buffer, *bytes.Buffer, tests.Restorer) 
 	util.Stdout = stdout
 	util.Stderr = stderr
 	os.Args = strings.Split(args, " ")
-	cfgFile = os.Getenv("PXTESTCONFIG")
 
 	return stdout, stderr, func() {
-		cfgFile = oldcfgFile
 		os.Args = oldargs
 		util.Stdout = oldStdout
 		util.Stderr = oldStderr
@@ -62,7 +59,7 @@ func pxTestSetupCli(args string) (*bytes.Buffer, *bytes.Buffer, tests.Restorer) 
 
 // runPx runs a command saved in os.Args and returns the error if any
 func runPx() error {
-	return rootCmd.Execute()
+	return Main()
 }
 
 // genVolName generates a unique name for a volume appended to a prefix

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -21,14 +21,18 @@ import (
 )
 
 // contextCmd represents the context command
-var contextCmd = &cobra.Command{
-	Use:   "context",
-	Short: "Manage connections to Portworx and other systems",
-	Run: func(cmd *cobra.Command, args []string) {
-		util.Printf("Please see px context --help for more commands")
-	},
-}
+var contextCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	contextCmd = &cobra.Command{
+		Use:   "context",
+		Short: "Manage connections to Portworx and other systems",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.Printf("Please see px context --help for more commands")
+		},
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	rootCmd.AddCommand(contextCmd)
-}
+})

--- a/cmd/contextCreate.go
+++ b/cmd/contextCreate.go
@@ -25,25 +25,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// contextCreateCmd represents the contextCreate command
-var contextCreateCmd = &cobra.Command{
-	Use:     "create [NAME]",
-	Short:   "Create a context",
-	Example: "$ px context create mycluster --endpoint=123.456.1.10:9020",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("Must supply a name for context")
-		}
-		return nil
-	},
-	Long: `A context is the information needed to connect to
+var contextCreateCmd *cobra.Command
+
+var _ = RegisterCommandVar(func() {
+	// contextCreateCmd represents the contextCreate command
+	contextCreateCmd = &cobra.Command{
+		Use:     "create [NAME]",
+		Short:   "Create a context",
+		Example: "$ px context create mycluster --endpoint=123.456.1.10:9020",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return fmt.Errorf("Must supply a name for context")
+			}
+			return nil
+		},
+		Long: `A context is the information needed to connect to
 Portworx and any other system. This information will be saved
 to a file called config.yml in a directory called .px under
 your home directory.`,
-	RunE: contextCreateExec,
-}
+		RunE: contextCreateExec,
+	}
+})
 
-func init() {
+var _ = RegisterCommandInit(func() {
 	contextCmd.AddCommand(contextCreateCmd)
 
 	contextCreateCmd.Flags().String("token", "", "Token for use in this context")
@@ -51,7 +55,7 @@ func init() {
 	contextCreateCmd.Flags().Bool("secure", false, "Use secure connection")
 	contextCreateCmd.Flags().String("cafile", "", "Path to client CA certificate if needed")
 	contextCreateCmd.Flags().String("kubeconfig", "", "Path to Kubeconfig file if any")
-}
+})
 
 func contextCreateExec(cmd *cobra.Command, args []string) error {
 

--- a/cmd/contextCurrent.go
+++ b/cmd/contextCurrent.go
@@ -21,17 +21,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// contextCurrentCmd represents the contextCurrent command
-var contextCurrentCmd = &cobra.Command{
-	Use:     "current",
-	Aliases: []string{"show", "current-context"},
-	Short:   "Show current context name",
-	RunE:    contextCurrentExec,
-}
+var contextCurrentCmd *cobra.Command
 
-func init() {
+// contextCurrentCmd represents the contextCurrent command
+var _ = RegisterCommandVar(func() {
+	contextCurrentCmd = &cobra.Command{
+		Use:     "current",
+		Aliases: []string{"show", "current-context"},
+		Short:   "Show current context name",
+		RunE:    contextCurrentExec,
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	contextCmd.AddCommand(contextCurrentCmd)
-}
+})
 
 func contextCurrentExec(cmd *cobra.Command, args []string) error {
 	contextManager, err := contextconfig.NewContextManager(GetConfigFile())

--- a/cmd/contextDelete.go
+++ b/cmd/contextDelete.go
@@ -23,28 +23,32 @@ import (
 )
 
 // contextDeleteCmd represents the contextDelete command
-var contextDeleteCmd = &cobra.Command{
-	Use:     "delete [NAME]",
-	Short:   "Deletes the given context",
-	Example: "$ px context delete mycontext",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("Must supply a name for context")
-		}
-		return nil
-	},
-	Long: `Usage:
+var contextDeleteCmd *cobra.Command
+
+var _ = RegisterCommandVar(func() {
+	contextDeleteCmd = &cobra.Command{
+		Use:     "delete [NAME]",
+		Short:   "Deletes the given context",
+		Example: "$ px context delete mycontext",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return fmt.Errorf("Must supply a name for context")
+			}
+			return nil
+		},
+		Long: `Usage:
 px context delete --name context1
 	`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return contextDeleteExec(cmd, args)
-	},
-}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return contextDeleteExec(cmd, args)
+		},
+	}
+})
 
-func init() {
+var _ = RegisterCommandInit(func() {
 	contextCmd.AddCommand(contextDeleteCmd)
 	contextDeleteCmd.Flags().String("name", "", "Name of context to delete")
-}
+})
 
 func contextDeleteExec(cmd *cobra.Command, args []string) error {
 	nameToDelete := args[0]

--- a/cmd/contextList.go
+++ b/cmd/contextList.go
@@ -21,19 +21,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// contextGetCmd represents the contextGet command
-var contextListCmd = &cobra.Command{
-	Use:     "list",
-	Aliases: []string{"contexts", "ctx"},
-	Short:   "List all context configurations",
-	Long: `List all context configurations
-px get context`,
-	RunE: contextListExec,
-}
+var contextListCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	contextListCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"contexts", "ctx"},
+		Short:   "List all context configurations",
+		Long: `List all context configurations
+px get context`,
+		RunE: contextListExec,
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	contextCmd.AddCommand(contextListCmd)
-}
+})
 
 func contextListExec(cmd *cobra.Command, args []string) error {
 	contextManager, err := contextconfig.NewContextManager(GetConfigFile())

--- a/cmd/contextSet.go
+++ b/cmd/contextSet.go
@@ -23,25 +23,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// setCurrentContextCmd represents the setCurrentContext command
-var contextSetCmd = &cobra.Command{
-	Use:     "set [NAME]",
-	Aliases: []string{"use"},
-	Example: "$ px context set mynewcontext",
-	Short:   "Set the current context configuration",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("Must supply a name for context")
-		}
-		return nil
-	},
-	Long: ``,
-	RunE: contextSetExec,
-}
+var contextSetCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	contextSetCmd = &cobra.Command{
+		Use:     "set [NAME]",
+		Aliases: []string{"use"},
+		Example: "$ px context set mynewcontext",
+		Short:   "Set the current context configuration",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return fmt.Errorf("Must supply a name for context")
+			}
+			return nil
+		},
+		Long: ``,
+		RunE: contextSetExec,
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	contextCmd.AddCommand(contextSetCmd)
-}
+})
 
 func contextSetExec(cmd *cobra.Command, args []string) error {
 	name := args[0]

--- a/cmd/contextUnset.go
+++ b/cmd/contextUnset.go
@@ -20,19 +20,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// contextUnsetCmd represents the unset current context command
-var contextUnsetCmd = &cobra.Command{
-	Use:   "unset",
-	Short: "Unset the current context configuration",
-	Long:  ``,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return contextUnsetExec(cmd, args)
-	},
-}
+var contextUnsetCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	contextUnsetCmd = &cobra.Command{
+		Use:   "unset",
+		Short: "Unset the current context configuration",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return contextUnsetExec(cmd, args)
+		},
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	contextCmd.AddCommand(contextUnsetCmd)
-}
+})
 
 func contextUnsetExec(cmd *cobra.Command, args []string) error {
 	contextManager, err := contextconfig.NewContextManager(GetConfigFile())

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -20,15 +20,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// createCmd represents the create command
-var createCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create an object in Portworx",
-	Run: func(cmd *cobra.Command, args []string) {
-		util.Printf("Please see px create --help for more information")
-	},
-}
+var createCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	createCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create an object in Portworx",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.Printf("Please see px create --help for more information")
+		},
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	rootCmd.AddCommand(createCmd)
-}
+})

--- a/cmd/createClone.go
+++ b/cmd/createClone.go
@@ -22,25 +22,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// createCloneCmd represents the createClone command
-var createCloneCmd = &cobra.Command{
-	Use:   "volumeclone [VOLUME] [NAME]",
-	Short: "Creates a new volume from a volume or snapshot",
-	Long:  `Create a clone for the specified volume`,
-	Example: `$ px create volumeclone oldvolume newvolume
-This creates a new volume called 'newvolume' from an existing volume called 'oldvolume'`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 2 {
-			return fmt.Errorf("Must supply the volume to clone and a new name for the clone")
-		}
-		return nil
-	},
-	RunE: createCloneExec,
-}
+var createCloneCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	createCloneCmd = &cobra.Command{
+		Use:   "volumeclone [VOLUME] [NAME]",
+		Short: "Creates a new volume from a volume or snapshot",
+		Long:  `Create a clone for the specified volume`,
+		Example: `$ px create volumeclone oldvolume newvolume
+This creates a new volume called 'newvolume' from an existing volume called 'oldvolume'`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return fmt.Errorf("Must supply the volume to clone and a new name for the clone")
+			}
+			return nil
+		},
+		RunE: createCloneExec,
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	createCmd.AddCommand(createCloneCmd)
-}
+})
 
 func createCloneExec(cmd *cobra.Command, args []string) error {
 	ctx, conn, err := PxConnectDefault()

--- a/cmd/createCloudmigration.go
+++ b/cmd/createCloudmigration.go
@@ -30,20 +30,24 @@ type cloudMigrationCreateOpts struct {
 }
 
 var (
+	ccmOpts                 cloudMigrationCreateOpts
+	createCloudmigrationCmd *cobra.Command
+)
+
+var _ = RegisterCommandVar(func() {
 	ccmOpts = cloudMigrationCreateOpts{
 		req: &api.SdkCloudMigrateStartRequest{},
 	}
-)
 
-// createCloudmigrationCmd represents the createCloudMigration command
-var createCloudmigrationCmd = &cobra.Command{
-	Use:   "cloudmigration",
-	Short: "Start a cloud migration",
-	Long:  `TODO Add long description`,
-	RunE:  createCloudmigrationExec,
-}
+	createCloudmigrationCmd = &cobra.Command{
+		Use:   "cloudmigration",
+		Short: "Start a cloud migration",
+		Long:  `TODO Add long description`,
+		RunE:  createCloudmigrationExec,
+	}
+})
 
-func init() {
+var _ = RegisterCommandInit(func() {
 	createCmd.AddCommand(createCloudmigrationCmd)
 
 	createCloudmigrationCmd.Flags().BoolVarP(&ccmOpts.all, "all", "a", false, "Migrate all volumes")
@@ -52,7 +56,7 @@ func init() {
 	createCloudmigrationCmd.Flags().StringVarP(&ccmOpts.req.ClusterId, "cluster-id", "c", "", "ID of the cluster in which volumes are to be migrated")
 	createCloudmigrationCmd.Flags().StringVarP(&ccmOpts.req.TaskId, "task-id", "t", "", "Unique name assocaiated with this migration for idempotency (optional).")
 	createCloudmigrationCmd.Flags().SortFlags = false
-}
+})
 
 func createCloudmigrationExec(cmd *cobra.Command, args []string) error {
 	ctx, conn, err := PxConnectDefault()

--- a/cmd/createClusterpair.go
+++ b/cmd/createClusterpair.go
@@ -35,25 +35,29 @@ type createClusterpairOpts struct {
 }
 
 var (
+	ccpOpts              createClusterpairOpts
+	createClusterpairCmd *cobra.Command
+)
+
+var _ = RegisterCommandVar(func() {
 	ccpOpts = createClusterpairOpts{
 		req: &api.ClusterPairCreateRequest{},
 	}
-)
 
-// createClusterpairCmd represents the createClusterpair command
-var createClusterpairCmd = &cobra.Command{
-	Use:     "clusterpair",
-	Aliases: []string{"clusterpairs"},
-	Short:   "Pair this cluster with another Portworx cluster",
-	Example: "$ px create clusterpair TODO ADD EXAMPLEs",
-	Long: `TODO
+	createClusterpairCmd = &cobra.Command{
+		Use:     "clusterpair",
+		Aliases: []string{"clusterpairs"},
+		Short:   "Pair this cluster with another Portworx cluster",
+		Example: "$ px create clusterpair TODO ADD EXAMPLEs",
+		Long: `TODO
 
 ADD EXAMPLES
 	`,
-	RunE: createClusterpairExec,
-}
+		RunE: createClusterpairExec,
+	}
+})
 
-func init() {
+var _ = RegisterCommandVar(func() {
 	createCmd.AddCommand(createClusterpairCmd)
 
 	createClusterpairCmd.Flags().StringVarP(&ccpOpts.source, "source", "s", "", "Context for the source cluster (required)")
@@ -63,7 +67,7 @@ func init() {
 	createClusterpairCmd.Flags().StringVarP(&ccpOpts.mode, "mode", "m", "", "Pairing mode to use (optional)")
 	createClusterpairCmd.Flags().BoolVarP(&ccpOpts.req.SetDefault, "set-default", "", false, "Set this as the default cluster pair (optional)")
 	createClusterpairCmd.Flags().SortFlags = false
-}
+})
 
 func createClusterpairExec(cmd *cobra.Command, args []string) error {
 	contextManager, err := contextconfig.NewContextManager(GetConfigFile())

--- a/cmd/createSnapshot.go
+++ b/cmd/createSnapshot.go
@@ -28,31 +28,35 @@ type createSnapshotOpts struct {
 }
 
 var (
+	csOpts            *createSnapshotOpts
+	createSnapshotCmd *cobra.Command
+)
+
+var _ = RegisterCommandVar(func() {
 	csOpts = &createSnapshotOpts{
 		req: &api.SdkVolumeSnapshotCreateRequest{},
 	}
-)
 
-// createSnapshotCmd represents the createSnapshot command
-var createSnapshotCmd = &cobra.Command{
-	Use:   "volumesnapshot [VOLUME] [NAME]",
-	Short: "Create a volume snapshot",
-	Long:  `Create a snapshot for the specified volume`,
-	Example: `$ px create volumesnapshot mysnap --labels color=blue,fabric=wool --volume myvol
+	createSnapshotCmd = &cobra.Command{
+		Use:   "volumesnapshot [VOLUME] [NAME]",
+		Short: "Create a volume snapshot",
+		Long:  `Create a snapshot for the specified volume`,
+		Example: `$ px create volumesnapshot mysnap --labels color=blue,fabric=wool --volume myvol
 This creates a snapshot named mysnap for the specified volume myvol.`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 2 {
-			return fmt.Errorf("Must supply the volume to snap and a new name for the snapshot")
-		}
-		return nil
-	},
-	RunE: createSnapshotExec,
-}
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return fmt.Errorf("Must supply the volume to snap and a new name for the snapshot")
+			}
+			return nil
+		},
+		RunE: createSnapshotExec,
+	}
+})
 
-func init() {
+var _ = RegisterCommandVar(func() {
 	createCmd.AddCommand(createSnapshotCmd)
 	createSnapshotCmd.Flags().StringVar(&csOpts.labelsAsString, "labels", "", "Comma separated list of labels as key-value pairs: 'k1=v1,k2=v2'")
-}
+})
 
 func createSnapshotExec(cmd *cobra.Command, args []string) error {
 	ctx, conn, err := PxConnectDefault()

--- a/cmd/createVolume.go
+++ b/cmd/createVolume.go
@@ -31,31 +31,35 @@ type createVolumeOpts struct {
 }
 
 var (
+	cvOpts          *createVolumeOpts
+	createVolumeCmd *cobra.Command
+)
+
+var _ = RegisterCommandVar(func() {
+	// createVolumeCmd represents the createVolume command
 	cvOpts = &createVolumeOpts{
 		req: &api.SdkVolumeCreateRequest{
 			Spec: &api.VolumeSpec{},
 		},
 	}
-)
+	createVolumeCmd = &cobra.Command{
+		Use:   "volume [NAME]",
+		Short: "Create a volume in Portworx",
 
-// createVolumeCmd represents the createVolume command
-var createVolumeCmd = &cobra.Command{
-	Use:   "volume [NAME]",
-	Short: "Create a volume in Portworx",
-
-	// TODO:
-	Example: `$ px create volume myvolume --size=3
+		// TODO:
+		Example: `$ px create volume myvolume --size=3
 This creates a volume called 'myvolume' of 3Gi.`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("Must supply a name for volume")
-		}
-		return nil
-	},
-	RunE: createVolumeExec,
-}
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return fmt.Errorf("Must supply a name for volume")
+			}
+			return nil
+		},
+		RunE: createVolumeExec,
+	}
+})
 
-func init() {
+var _ = RegisterCommandInit(func() {
 	createCmd.AddCommand(createVolumeCmd)
 
 	createVolumeCmd.Flags().IntVar(&cvOpts.sizeInGi, "size", 0, "Size in GiB")
@@ -67,7 +71,7 @@ func init() {
 	// TODO bring the flags from rootCmd
 
 	// TODO add more flags here
-}
+})
 
 func createVolumeExec(cmd *cobra.Command, args []string) error {
 	ctx, conn, err := PxConnectDefault()

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -19,15 +19,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// deleteCmd represents the delete command
-var deleteCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete an object in Portworx",
-	Run: func(cmd *cobra.Command, args []string) {
-		util.Printf("Please see px delete --help for more information")
-	},
-}
+var deleteCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	deleteCmd = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete an object in Portworx",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.Printf("Please see px delete --help for more information")
+		},
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	rootCmd.AddCommand(deleteCmd)
-}
+})

--- a/cmd/deleteVolume.go
+++ b/cmd/deleteVolume.go
@@ -22,23 +22,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// deleteVolumeCmd represents the deleteVolume command
-var deleteVolumeCmd = &cobra.Command{
-	Use:     "volume [NAME]",
-	Short:   "Delete a volume in Portworx",
-	Example: "$ px delete volume myvolume",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("Must supply a volume name")
-		}
-		return nil
-	},
-	RunE: deleteVolumeExec,
-}
+var deleteVolumeCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	// deleteVolumeCmd represents the deleteVolume command
+	deleteVolumeCmd = &cobra.Command{
+		Use:     "volume [NAME]",
+		Short:   "Delete a volume in Portworx",
+		Example: "$ px delete volume myvolume",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return fmt.Errorf("Must supply a volume name")
+			}
+			return nil
+		},
+		RunE: deleteVolumeExec,
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	deleteCmd.AddCommand(deleteVolumeCmd)
-}
+})
 
 func deleteVolumeExec(cmd *cobra.Command, args []string) error {
 	ctx, conn, err := PxConnectDefault()

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -19,15 +19,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// describeCmd represents the describe command
-var describeCmd = &cobra.Command{
-	Use:   "describe",
-	Short: "Show detailed information of Portworx resources",
-	Run: func(cmd *cobra.Command, args []string) {
-		util.Printf("Please see px describe --help for more information")
-	},
-}
+var describeCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	describeCmd = &cobra.Command{
+		Use:   "describe",
+		Short: "Show detailed information of Portworx resources",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.Printf("Please see px describe --help for more information")
+		},
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	rootCmd.AddCommand(describeCmd)
-}
+})

--- a/cmd/describeVolume.go
+++ b/cmd/describeVolume.go
@@ -34,28 +34,32 @@ const (
 	timeLayout = "Jan 2 15:04:05 UTC 2006"
 )
 
-// describeVolumeCmd represents the describeVolume command
-var describeVolumeCmd = &cobra.Command{
-	Use:     "volume",
-	Aliases: []string{"volumes"},
-	Short:   "Describe a Portworx volume",
-	Long:    "Show detailed information of Portworx volumes",
-	Example: `$ px describe volume
+var describeVolumeCmd *cobra.Command
+
+var _ = RegisterCommandVar(func() {
+	// describeVolumeCmd represents the describeVolume command
+	describeVolumeCmd = &cobra.Command{
+		Use:     "volume",
+		Aliases: []string{"volumes"},
+		Short:   "Describe a Portworx volume",
+		Long:    "Show detailed information of Portworx volumes",
+		Example: `$ px describe volume
   This describes all volumes
 $ px describe volume abc
   This describes volume abc
 $ px describe volume abc xyz
   This describes volumes abc and xyz`,
-	RunE: describeVolumesExec,
-}
+		RunE: describeVolumesExec,
+	}
+})
 
-func init() {
+var _ = RegisterCommandInit(func() {
 	describeCmd.AddCommand(describeVolumeCmd)
 	describeVolumeCmd.Flags().String("owner", "", "Owner of volume")
 	describeVolumeCmd.Flags().String("volumegroup", "", "Volume group id")
 	describeVolumeCmd.Flags().Bool("deep", false, "Collect more information, this may delay the request")
 	describeVolumeCmd.Flags().Bool("show-k8s-info", false, "Show kubernetes information")
-}
+})
 
 func describeVolumesExec(cmd *cobra.Command, args []string) error {
 	// Parse out all of the common cli volume flags

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -20,15 +20,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// getCmd represents the get command
-var getCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get information from Portworx",
-	Run: func(cmd *cobra.Command, args []string) {
-		util.Printf("Please see px get --help for more information")
-	},
-}
+var getCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	getCmd = &cobra.Command{
+		Use:   "get",
+		Short: "Get information from Portworx",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.Printf("Please see px get --help for more information")
+		},
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	rootCmd.AddCommand(getCmd)
-}
+})

--- a/cmd/getNodes.go
+++ b/cmd/getNodes.go
@@ -29,18 +29,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// getNodesCmd represents the getNodes command
-var getNodesCmd = &cobra.Command{
-	Use:     "node",
-	Aliases: []string{"nodes"},
-	Short:   "Get Portworx node information",
-	RunE:    getNodesExec,
-}
+var getNodesCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	getNodesCmd = &cobra.Command{
+		Use:     "node",
+		Aliases: []string{"nodes"},
+		Short:   "Get Portworx node information",
+		RunE:    getNodesExec,
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	getCmd.AddCommand(getNodesCmd)
 	getNodesCmd.Flags().StringP("output", "o", "", "Output in yaml|json|wide")
-}
+})
 
 func getNodesExec(cmd *cobra.Command, args []string) error {
 	// Parse out all of the common cli volume flags

--- a/cmd/getPvc.go
+++ b/cmd/getPvc.go
@@ -31,20 +31,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// getPvcCmd represents the getPvc command
-var getPvcCmd = &cobra.Command{
-	Use:     "pvc",
-	Aliases: []string{"pvcs"},
-	Short:   "Show Portworx volume information for Kuberntes PVCs",
-	RunE:    getPvcExec,
-}
+var getPvcCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	getPvcCmd = &cobra.Command{
+		Use:     "pvc",
+		Aliases: []string{"pvcs"},
+		Short:   "Show Portworx volume information for Kuberntes PVCs",
+		RunE:    getPvcExec,
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	getCmd.AddCommand(getPvcCmd)
 	getPvcCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace")
 	getPvcCmd.Flags().Bool("all-namespaces", false, "Kubernetes namespace")
 	getPvcCmd.Flags().StringP("output", "o", "", "Output in yaml|json|wide")
-}
+})
 
 func getPvcExec(cmd *cobra.Command, args []string) error {
 	// Parse out all of the common cli volume flags

--- a/cmd/getVolumes.go
+++ b/cmd/getVolumes.go
@@ -29,15 +29,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// getVolumesCmd represents the getVolumes command
-var getVolumesCmd = &cobra.Command{
-	Use:     "volume",
-	Aliases: []string{"volumes"},
-	Short:   "Get information about Portworx volumes",
-	RunE:    getVolumesExec,
-}
+var getVolumesCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	getVolumesCmd = &cobra.Command{
+		Use:     "volume",
+		Aliases: []string{"volumes"},
+		Short:   "Get information about Portworx volumes",
+		RunE:    getVolumesExec,
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	getCmd.AddCommand(getVolumesCmd)
 	getVolumesCmd.Flags().String("owner", "", "Owner of volume")
 	getVolumesCmd.Flags().String("volumegroup", "", "Volume group id")
@@ -46,7 +49,7 @@ func init() {
 	getVolumesCmd.Flags().StringP("output", "o", "", "Output in yaml|json|wide")
 
 	// TODO: Place here support for selectors and move the flags from the rootCmd
-}
+})
 
 func getVolumesExec(cmd *cobra.Command, args []string) error {
 	// Parse out all of the common cli volume flags

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,147 @@
+/*
+Copyright © 2019 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"os"
+	"path"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/portworx/px/pkg/kubernetes"
+	"github.com/portworx/px/pkg/portworx"
+	"github.com/portworx/px/pkg/util"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	kclikube "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	pxDefaultDir        = ".px"
+	pxDefaultConfigName = "config.yml"
+
+	Ki = 1024
+	Mi = 1024 * Ki
+	Gi = 1024 * Mi
+	Ti = 1024 * Gi
+)
+
+var (
+	cfgDir      string
+	cfgFile     string
+	cfgContext  string
+	optEndpoint string
+	// TODO Redo plugin model: pm          *plugin.PluginManager
+
+	// The $HOME/.px/plugins dir will be added at runtime
+	pxPluginDefaultDirs = []string{
+		"/var/lib/px/plugins",
+		"/etc/pwx/plugins",
+		"/opt/pwx/plugins",
+		"/var/lib/porx/plugins",
+	}
+
+	varInitFncs []func()
+	cmdInitFncs []func()
+)
+
+func init() {
+	cobra.OnInitialize(initConfig)
+}
+
+// initConfig reads in config file
+func initConfig() {
+	// If the cfgFile has not been setup in the arguments, then
+	// read it from the HOME directory
+	cfgFile = os.Getenv("PXCONFIG")
+	if len(cfgFile) == 0 {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			util.Eprintf("Error: %v\n", err)
+			os.Exit(1)
+		}
+		cfgFile = path.Join(home, pxDefaultDir, pxDefaultConfigName)
+	}
+}
+
+// GetConfigFile returns the current config file
+func GetConfigFile() string {
+	return cfgFile
+}
+
+// PxConnectDefault returns a Portworx client to the default or
+// named context
+func PxConnectDefault() (context.Context, *grpc.ClientConn, error) {
+	// Global information will be set here, like forced context
+	if len(cfgContext) == 0 {
+		return portworx.PxConnectCurrent(cfgFile)
+	} else {
+		return portworx.PxConnectNamed(cfgFile, cfgContext)
+	}
+}
+
+// KubeConnectDefault returns a Kubernetes client to the default
+// or named context.
+func KubeConnectDefault() (clientcmd.ClientConfig, *kclikube.Clientset, error) {
+	return kubernetes.KubeConnect(cfgFile, cfgContext)
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := Main(); err != nil {
+		util.Eprintf("%v\n", err)
+		os.Exit(1)
+	}
+}
+
+// RegisterCommandVar is used to register with px the initialization function
+// for the command variable.
+// Something must be returned to use the `var _ = ` trick.
+func RegisterCommandVar(c func()) bool {
+	varInitFncs = append(varInitFncs, c)
+
+	return true
+}
+
+// RegisterCommandInit is used to register with px the initialization function
+// for the command flags.
+// Something must be returned to use the `var _ = ` trick.
+func RegisterCommandInit(c func()) bool {
+	cmdInitFncs = append(cmdInitFncs, c)
+	return true
+}
+
+// Main starts the px cli
+// Stupid simple initialization
+func Main() error {
+	// Setup all variables.
+	// Setting up all the variables first will allow px
+	// to initialize the init functions in any order
+	for _, v := range varInitFncs {
+		v()
+	}
+
+	// Call all plugin inits
+	for _, f := range cmdInitFncs {
+		f()
+	}
+
+	// Execute px
+	return rootCmd.Execute()
+}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package cmd
 
+/*
+ * Plugins will be done in a future time
 import (
 	"github.com/portworx/px/pkg/util"
 	"github.com/spf13/cobra"
@@ -49,3 +51,4 @@ func pluginsExec(cmd *cobra.Command, args []string) {
 	}
 	t.Print()
 }
+*/

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,67 +16,23 @@ limitations under the License.
 package cmd
 
 import (
-	"context"
-	"os"
-	"path"
-
-	"github.com/portworx/px/pkg/kubernetes"
-	"github.com/portworx/px/pkg/plugin"
-	"github.com/portworx/px/pkg/portworx"
-	"github.com/portworx/px/pkg/util"
-
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	kclikube "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-)
-
-const (
-	pxDefaultDir        = ".px"
-	pxDefaultConfigName = "config.yml"
-
-	Ki = 1024
-	Mi = 1024 * Ki
-	Gi = 1024 * Mi
-	Ti = 1024 * Gi
-)
-
-var (
-	cfgDir      string
-	cfgFile     string
-	cfgContext  string
-	optEndpoint string
-	pm          *plugin.PluginManager
-
-	// The $HOME/.px/plugins dir will be added at runtime
-	pxPluginDefaultDirs = []string{
-		"/var/lib/px/plugins",
-		"/etc/pwx/plugins",
-		"/opt/pwx/plugins",
-		"/var/lib/porx/plugins",
-	}
 )
 
 // rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:           "px",
-	Short:         "Portworx command line tool",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-}
+var rootCmd *cobra.Command
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		util.Eprintf("%v\n", err)
-		os.Exit(1)
+var _ = RegisterCommandVar(func() {
+	// rootCmd represents the base command when called without any subcommands
+	rootCmd = &cobra.Command{
+		Use:           "px",
+		Short:         "Portworx command line tool",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
-}
+})
 
-func init() {
-	cobra.OnInitialize(initConfig)
+var _ = RegisterCommandInit(func() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/"+pxDefaultDir+"/"+pxDefaultConfigName+")")
 	rootCmd.PersistentFlags().StringVar(&cfgContext, "context", "", "Force context name for the command")
@@ -89,6 +45,7 @@ func init() {
 	rootCmd.Flags().SortFlags = false
 
 	// Load plugins
+	/* TODO: Redo Plugin model
 	home, _ := homedir.Dir()
 	pxPluginDefaultDirs = append(pxPluginDefaultDirs,
 		path.Join(home, pxDefaultDir, "plugins"))
@@ -97,36 +54,5 @@ func init() {
 		RootCmd:    rootCmd,
 	})
 	pm.Load()
-}
-
-// initConfig reads in config file
-func initConfig() {
-	// If the cfgFile has not been setup in the arguments, then
-	// read it from the HOME directory
-	if len(cfgFile) == 0 {
-		// Find home directory.
-		home, err := homedir.Dir()
-		if err != nil {
-			util.Eprintf("Error: %v\n", err)
-			os.Exit(1)
-		}
-		cfgFile = path.Join(home, pxDefaultDir, pxDefaultConfigName)
-	}
-}
-
-func GetConfigFile() string {
-	return cfgFile
-}
-
-func PxConnectDefault() (context.Context, *grpc.ClientConn, error) {
-	// Global information will be set here, like forced context
-	if len(cfgContext) == 0 {
-		return portworx.PxConnectCurrent(cfgFile)
-	} else {
-		return portworx.PxConnectNamed(cfgFile, cfgContext)
-	}
-}
-
-func KubeConnectDefault() (clientcmd.ClientConfig, *kclikube.Clientset, error) {
-	return kubernetes.KubeConnect(cfgFile, cfgContext)
-}
+	*/
+})

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -24,17 +24,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// statusCmd represents the status command
-var statusCmd = &cobra.Command{
-	Use: "status",
-	// TODO
-	Short: "TODO: this will move to px describe cluster",
-	RunE:  statusExec,
-}
+var statusCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	statusCmd = &cobra.Command{
+		Use: "status",
+		// TODO
+		Short: "TODO: this will move to px describe cluster",
+		RunE:  statusExec,
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	rootCmd.AddCommand(statusCmd)
-}
+})
 
 func statusExec(cmd *cobra.Command, args []string) error {
 	ctx, conn, err := PxConnectDefault()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -27,18 +27,21 @@ var (
 	PxVersion = "(DEV)"
 )
 
-// versionCmd represents the version command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Show px version information",
-	Run: func(cmd *cobra.Command, args []string) {
-		versionExec(cmd, args)
-	},
-}
+var versionCmd *cobra.Command
 
-func init() {
+var _ = RegisterCommandVar(func() {
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Show px version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			versionExec(cmd, args)
+		},
+	}
+})
+
+var _ = RegisterCommandInit(func() {
 	rootCmd.AddCommand(versionCmd)
-}
+})
 
 func versionExec(cmd *cobra.Command, args []string) {
 	// Print client version

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -33,7 +33,7 @@ stopdocker()
 startdocker pxutsource 9920
 startdocker pxuttarget 9921
 
-export PXTESTCONFIG=$PWD/hack/config.yml
+export PXCONFIG=$PWD/hack/config.yml
 
 result=0
 if [ $# -eq 0 ] ; then

--- a/main.go
+++ b/main.go
@@ -18,5 +18,5 @@ package main
 import "github.com/portworx/px/cmd"
 
 func main() {
-	cmd.Execute()
+	cmd.Main()
 }


### PR DESCRIPTION
This patch provides new infrastructure for the commands of px so
they can be used in normal operation and in the unit tests. The
main issue with the normal model is that the unit tests cannot
re-initialize the variables since they are initialized as global
variables and with the `init()` functions.

This patch provides a simple method for initializing variables
and the command flags by providing two functions:

* RegisterCommandVar
* RegisterCommandInit

These functions can be use the same model as used by Ginkgo. Here
is an example how they can be used:

```
var createCmd *cobra.Command

var _ = RegisterCommandVar(func() {
	createCmd = &cobra.Command{
		Use:   "create",
		Short: "Create an object in Portworx",
		Run: func(cmd *cobra.Command, args []string) {
			util.Printf("Please see px create "+
			"--help for more information")
		},
	}
})

var _ = RegisterCommandInit(func() {
	rootCmd.AddCommand(createCmd)
})
```

This patch also adds `cmd/main.go` to provide the appropriate
functions to re-initialize the command variables.

* Also added a new env variable [`PXCONFIG`](https://github.com/portworx/px/pull/32/files#diff-3002d695552ec7e7ebbaaf04a21d3439R70) which is used by unit tests to pass in the config file instead of the older "test" only code. Now it can be set by anyone at any time.