### PR TITLE
Adding --selector support in get volumes to query based on label

### DIFF
--- a/cmd/cliVolumeOps.go
+++ b/cmd/cliVolumeOps.go
@@ -33,6 +33,7 @@ type cliVolumeInputs struct {
 	// if namespace is "", use all-namespaces
 	// else use specified namespace
 	namespace *string
+	labels    map[string]string
 }
 
 type cliVolumeOps struct {
@@ -40,12 +41,16 @@ type cliVolumeOps struct {
 	pxVolumeOps portworx.PxVolumeOps
 }
 
-// Look for all of the common flags and create a new cliVolumeInputs object
+// GetCliVolumeInputs looks for all of the common flags and create a new cliVolumeInputs object
 func GetCliVolumeInputs(cmd *cobra.Command, args []string) *cliVolumeInputs {
 	showK8s, _ := cmd.Flags().GetBool("show-k8s-info")
 	output, _ := cmd.Flags().GetString("output")
 	showLabels, _ := cmd.Flags().GetBool("show-labels")
 	namespace := string("")
+	labels, _ := cmd.Flags().GetString("selector")
+	//convert string to map
+	mlabels, _ := util.CommaStringToStringMap(labels)
+	// If valid label is present, we need to pass it.
 	return &cliVolumeInputs{
 		BaseFormatOutput: util.BaseFormatOutput{
 			FormatType: output,
@@ -54,6 +59,7 @@ func GetCliVolumeInputs(cmd *cobra.Command, args []string) *cliVolumeInputs {
 		showLabels:  showLabels,
 		volumeNames: args,
 		namespace:   &namespace, // In most places use all namespaces
+		labels:      mlabels,
 	}
 }
 
@@ -124,6 +130,7 @@ func (p *cliVolumeOps) Connect() error {
 		},
 		Namespace: *p.namespace,
 		VolNames:  p.volumeNames,
+		Labels:    p.labels,
 	}
 
 	p.pxVolumeOps, err = portworx.NewPxVolumeOps(volOpsInfo)

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -95,7 +95,17 @@ func executeCli(cli string) ([]string, []string, error) {
 // Takes a volume name and size. Returns the created volume id.
 // For some reason our test container only recoganizes id and not name for some calls.
 func testCreateVolume(t *testing.T, volName string, size uint64) {
-	cli := "px create volume " + volName + " --size " + strconv.FormatUint(size, 10)
+	cli := fmt.Sprintf("px create volume %s --size %s", volName, strconv.FormatUint(size, 10))
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
+	assert.True(t, util.ListContainsSubString(lines, fmt.Sprintf("Volume %s created with id", volName)))
+}
+
+// Takes a volume name and size. Returns the created volume id.
+func testCreateVolumeWithLabel(t *testing.T, volName string, size uint64, labels string) {
+	cli := fmt.Sprintf("px create volume %s --size %s --labels %s",
+		volName, strconv.FormatUint(size, 10), labels)
 	lines, _, err := executeCli(cli)
 	assert.NoError(t, err)
 
@@ -109,6 +119,18 @@ func testHasVolume(id string) bool {
 	_, _, err := executeCli(cli)
 
 	return err == nil
+}
+
+func testGetVolumeWithLabels(t *testing.T, selector string) (*bytes.Buffer, error) {
+	cli := fmt.Sprintf("px get volume --show-labels --selector %s", selector)
+	so, _, err := executeCliRaw(cli)
+	return so, err
+}
+
+func testGetVolumeWithNameSelector(t *testing.T, volName string, selector string) {
+	cli := fmt.Sprintf("px get volume %s --show-labels --selector %s", volName, selector)
+	_, _, err := executeCliRaw(cli)
+	assert.Error(t, err)
 }
 
 // Return volume information
@@ -134,7 +156,7 @@ func testVolumeInfo(t *testing.T, id string) *api.Volume {
 //       parse, and as a library function, it may be easier to
 //       get a specific volume.
 func testGetAllVolumes(t *testing.T) []string {
-	cli := "px get volume"
+	cli := fmt.Sprintf("px get volume")
 	lines, _, err := executeCli(cli)
 	assert.NoError(t, err)
 
@@ -152,7 +174,7 @@ func testGetAllVolumes(t *testing.T) []string {
 
 // Deletes specified volume
 func testDeleteVolume(t *testing.T, volName string) {
-	cli := "px delete volume " + volName
+	cli := fmt.Sprintf("px delete volume %s", volName)
 	_, _, err := executeCli(cli)
 	assert.NoError(t, err)
 }

--- a/cmd/getVolumes_test.go
+++ b/cmd/getVolumes_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright © 2019 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    httd://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"testing"
+
+	_ "github.com/portworx/px/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+//To test successful case.
+func TestGetVolumeWithLabels(t *testing.T) {
+	//creating volumes with lables
+	volName := genVolName("labelvol")
+	selector := "type=labelvol"
+
+	// Create Volume with label
+	testCreateVolumeWithLabel(t, volName, 1, selector)
+	assert.True(t, testHasVolume(volName))
+
+	// Delete the created volume
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
+}
+
+// Test to error out when --selector is provided along with volume name
+func TestGetVolumeWithNameSelector(t *testing.T) {
+	//creating volumes with lables
+	volName := genVolName("labelvol")
+	selector := "type1=labelvol"
+
+	// Create Volume with label
+	testCreateVolumeWithLabel(t, volName, 1, selector)
+	testGetVolumeWithNameSelector(t, volName, selector)
+
+	// Delete the created volume
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
+}
+
+//Test passing k,v pair which is not present
+func TestGetVolumeWithDummySelector(t *testing.T) {
+	//creating volumes with lables
+	volName := genVolName("labelvol")
+	selector := "type1=labelvol"
+	dummySelector := "invalid=label"
+
+	// Create Volume with label
+	testCreateVolumeWithLabel(t, volName, 1, selector)
+	so, _ := testGetVolumeWithLabels(t, dummySelector)
+	assert.Contains(t, so.String(), "No resources found")
+
+	// Delete the created volume
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
+}
+
+//Test to error is inavlid (k,v) label pair is provided.
+func TestGetVolumeInvalidLabels(t *testing.T) {
+	//creating volumes with lables
+	volName := genVolName("labelvol")
+	selector := "type1=labelvol"
+	invalidSelector := "type1,labelvol"
+
+	// Create Volume
+	testCreateVolumeWithLabel(t, volName, 1, selector)
+	_, err := testGetVolumeWithLabels(t, invalidSelector)
+	assert.Error(t, err)
+
+	// Delete the created volume
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,7 @@ var _ = RegisterCommandInit(func() {
 	rootCmd.PersistentFlags().StringVar(&cfgContext, "context", "", "Force context name for the command")
 
 	// TODO: move these flags out of persistent
-	rootCmd.PersistentFlags().StringP("selector", "l", "", "Comma separated label selector of the form 'key=value,key=value'")
+	rootCmd.PersistentFlags().Bool("show-labels", false, "Show labels in the last column of the output")
 
 	// Global cobra configurations
 	rootCmd.Flags().SortFlags = false

--- a/pkg/portworx/pxVolumeOps.go
+++ b/pkg/portworx/pxVolumeOps.go
@@ -58,6 +58,7 @@ type PxVolumeOpsInfo struct {
 	VolNames []string
 	// node ids
 	NodeIds []string
+	Labels  map[string]string
 }
 
 func (p *PxVolumeOpsInfo) Close() {
@@ -148,8 +149,17 @@ func (p *pxVolumeOps) GetVolumes() ([]*api.SdkVolumeInspectResponse, error) {
 		}
 	} else {
 		// If it is no volumes (all)
-		volsInfo, err := volumes.InspectWithFilters(p.pxVolumeOpsInfo.Ctx,
-			&api.SdkVolumeInspectWithFiltersRequest{})
+		var (
+			err      error
+			volsInfo *api.SdkVolumeInspectWithFiltersResponse
+		)
+
+		// if label is set, use them as filter
+		volsInfo, err = volumes.InspectWithFilters(p.pxVolumeOpsInfo.Ctx,
+			&api.SdkVolumeInspectWithFiltersRequest{
+				Labels: p.GetPxVolumeOpsInfo().Labels,
+			})
+
 		if err != nil {
 			return nil, util.PxErrorMessage(err, "Failed to get volumes")
 		}


### PR DESCRIPTION
Part of #18 

- Supporting --selector flags in "get volumes" to filter out volumes listing based on provided labels.
- UT's for the same
