### PR TITLE
    Adding following flags --sticky, --journal, --encrypted, --aggregation_level, --io_profile, --ReplicaSet for create volume

### DIFF
--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -196,3 +196,53 @@ func testCreateClone(t *testing.T, volId string, cloneName string) {
 
 	assert.True(t, util.ListContainsSubString(lines, fmt.Sprintf("Clone of %s created with id", volId)))
 }
+
+// Helper function to create volume with "sticky" flag set
+func testCreateStickyVolume(t *testing.T, volName string, size uint64) {
+	cli := fmt.Sprintf("px create volume %s --size %d --sticky",
+		volName, size)
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
+	assert.True(t, util.ListContainsSubString(lines, fmt.Sprintf("Volume %s created with id", volName)))
+}
+
+// Helper function to create volume with "encryption" flag set
+func testCreateEncrypVolume(t *testing.T, volName string, size uint64) {
+	cli := fmt.Sprintf("px create volume %s --size %d --encryption",
+		volName, size)
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
+	assert.True(t, util.ListContainsSubString(lines, fmt.Sprintf("Volume %s created with id", volName)))
+}
+
+// Helper function to create volume with "journal" flag set
+func testCreateJournalVolume(t *testing.T, volName string, size uint64) {
+	cli := fmt.Sprintf("px create volume %s --size %d --journal",
+		volName, size)
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
+	assert.True(t, util.ListContainsSubString(lines, fmt.Sprintf("Volume %s created with id", volName)))
+}
+
+// Helper function to create volume with "aggregation level" flag set
+func testCreateAggrVolume(t *testing.T, volName string, size uint64, aggrLevel uint32) {
+	cli := fmt.Sprintf("px create volume %s --size %d --aggregation-level %d",
+		volName, size, aggrLevel)
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
+	assert.True(t, util.ListContainsSubString(lines, fmt.Sprintf("Volume %s created with id", volName)))
+}
+
+// Helper function to create volume with "io profile" flag set
+func testCreateIoProfVolume(t *testing.T, volName string, size uint64, IoProfile string) {
+	cli := fmt.Sprintf("px create volume %s --size %d --ioprofile %s",
+		volName, size, IoProfile)
+	lines, _, err := executeCli(cli)
+	assert.NoError(t, err)
+
+	assert.True(t, util.ListContainsSubString(lines, fmt.Sprintf("Volume %s created with id", volName)))
+}

--- a/cmd/createVolume_test.go
+++ b/cmd/createVolume_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright © 2019 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    httd://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Testing creation of volume with "sticky" flag set.
+func TestCreateStickyVolume(t *testing.T) {
+	volName := genVolName("stickyVol")
+
+	// Create volume with "sticky" flag set
+	testCreateStickyVolume(t, volName, 1)
+	assert.True(t, testHasVolume(volName))
+
+	// Delete Volume
+	// TODO: Place holder for unsetting sticky flag and then deleting it.
+	// Will be done once update patch is in
+	// testDeleteVolume(t, volName)
+	// assert.False(t, testHasVolume(volName))
+}
+
+// Testing creation of volume with "encryption" flag set.
+func TestCreateEncrypVolume(t *testing.T) {
+	volName := genVolName("encrypVol")
+
+	// Create volume with "sticky" flag set
+	testCreateEncrypVolume(t, volName, 1)
+	assert.True(t, testHasVolume(volName))
+
+	// Delete Volume
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
+}
+
+// Testing creation of volume with "journal" flag set.
+func TestCreateJournalVolume(t *testing.T) {
+	volName := genVolName("journalVol")
+
+	// Create volume with "journal" flag set
+	testCreateJournalVolume(t, volName, 1)
+	assert.True(t, testHasVolume(volName))
+
+	// Delete Volume
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
+}
+
+// Testing creation of volume with "aggregation" flag set.
+func TestCreateAggrVolume(t *testing.T) {
+	volName := genVolName("aggrVol")
+	aggrLevel := 2
+
+	// Create volume with "journal" flag set
+	testCreateAggrVolume(t, volName, 1, uint32(aggrLevel))
+	assert.True(t, testHasVolume(volName))
+
+	// Delete Volume
+	testDeleteVolume(t, volName)
+	assert.False(t, testHasVolume(volName))
+}
+
+// Testing creation of volume with different IO profile.
+func TestCreateIoProfVolume(t *testing.T) {
+	ioProfile := []string{"cms", "db_remote", "sync_shared"}
+
+	for _, profile := range ioProfile {
+		volName := genVolName("ioprofVol")
+		testCreateIoProfVolume(t, volName, 1, profile)
+		assert.True(t, testHasVolume(volName))
+
+		// Delete Volume
+		testDeleteVolume(t, volName)
+		assert.False(t, testHasVolume(volName))
+	}
+}


### PR DESCRIPTION
Adding support for following flags in volume creation
 --sticky, --journal, --encrypted, --aggregation_level, --io_profile, --ReplicaSet

Manual test
------------
```
 **Creating IO profile with "cms"**
  Prashanths-MacBook-Pro:px prashanthkumar$ ./px create volume cmsvol --size 1 --ioprofile "cms"
Volume cmsvol created with id 736120619180674475Prashanths-MacBook-Pro:px prashanthkumar$

Verifying the same
[root@prashanth-blr-dev-1 ~]# pxctl v i cmsvol -j | less | grep profile
  "io_profile": "cms",

Invalid IO profile
Prashanths-MacBook-Pro:px prashanthkumar$ ./px create volume cmsvol --size 1 --ioprofile "cmsfdefewf"
Invalid IO profile

```

```

**Sticky vol creation**
================
Prashanths-MacBook-Pro:px prashanthkumar$ ./px create volume stickvol --size 1 --sticky
Volume stickvol created with id 1140376121858303735Prashanths-MacBook-Pro:px prashanthkumar$


Prashanths-MacBook-Pro:px prashanthkumar$ ./px describe volume stickvol
Volume:         1140376121858303735
Name:           stickvol
Size:           1.0 GiB
Format:         NONE
HA:             1
IO Priority:    LOW
Creation Time:  Aug 10 10:32:46 UTC 2019
Shared:         no
Status:         UP
State:          Detached
Attributes:     sticky >>>>>>>>>> "sticky is set"
Stats:
  Reads:             0
  Reads MS:          0
  Bytes Read:        0
  Writes:            0
  Writes MS:         0
  Bytes Written:     0
  IOs in progress:   0
  Bytes used:        0 B
Replication Status:  Detached
Replica sets on nodes:
  Set:     0
    Node:  prashanth-blr-dev-2 (Pool 1)```

```
Aggregation volume
==================
Prashanths-MacBook-Pro:px prashanthkumar$ ./px create volume aggrvol --size 1 --aggregation_level 2
Volume aggrvol created with id 24619819322265772Prashanths-MacBook-Pro:px prashanthkumar$


Prashanths-MacBook-Pro:px prashanthkumar$ ./px describe volume aggrvol
Volume:         24619819322265772
Name:           aggrvol
Size:           1.0 GiB
Format:         NONE
HA:             1
IO Priority:    LOW
Creation Time:  Aug 10 10:34:04 UTC 2019
Shared:         no
Status:         UP
State:          Detached
Stats:
  Reads:             0
  Reads MS:          0
  Bytes Read:        0
  Writes:            0
  Writes MS:         0
  Bytes Written:     0
  IOs in progress:   0
  Bytes used:        0 B
Replication Status:  Detached
Replica sets on nodes:
  Set:     0
    Node:  prashanth-blr-dev-2 (Pool 1)
  Set:     1
    Node:  prashanth-blr-dev-3 (Pool 1) >>>> aggregated on two values
```

```
**Journal flag setting**
Prashanths-MacBook-Pro:px prashanthkumar$ ./px create volume journalvol --size 1 --journal
Volume journalvol created with id 568286096671170675Prashanths-MacBook-Pro:px prashanthkumar$


[root@prashanth-blr-dev-1 ~]# pxctl v i journalvol -j | less | grep journal
  "name": "journalvol"
  "journal": true,
[root@prashanth-blr-dev-1 ~]#```

```
Setting replica state
Prashanths-MacBook-Pro:px prashanthkumar$ ./px get nodes -o wide
Id                                    Hostname             IP          Data IP     SchedulerNodeName    Used  Capacity  # Disks  # Pools  Status
--                                    --------             --          -------     -----------------    ----  --------  -------  -------  ------
08bb10a8-387b-4a32-8523-492ee9bb7a9e  prashanth-blr-dev-3  70.0.79.17  70.0.79.17  prashanth-blr-dev-3  0 B   0 B       0        0        STATUS_OK
46f8a110-4c49-4708-9e6b-d234e6572aa3  prashanth-blr-dev-1  70.0.79.19  70.0.79.19  prashanth-blr-dev-1  0 B   0 B       0        0        STATUS_OK
75354d38-1c76-4ddb-b359-40cee021b8e0  prashanth-blr-dev-2  70.0.79.18  70.0.79.18  prashanth-blr-dev-2  0 B   0 B       0        0        STATUS_OK
Prashanths-MacBook-Pro:px prashanthkumar$



Replica set nodes
Prashanths-MacBook-Pro:px prashanthkumar$ ./px create volume replvol --nodes 75354d38-1c76-4ddb-b359-40cee021b8e0
Volume replvol created with id 986609237916635577Prashanths-MacBook-Pro:px prashanthkumar$

Prashanths-MacBook-Pro:px prashanthkumar$ ./px describe volume replvol
Volume:         986609237916635577
Name:           replvol
Size:           1.0 GiB
Format:         NONE
HA:             1
IO Priority:    LOW
Creation Time:  Aug 10 10:42:07 UTC 2019
Shared:         no
Status:         UP
State:          Detached
Stats:
  Reads:             0
  Reads MS:          0
  Bytes Read:        0
  Writes:            0
  Writes MS:         0
  Bytes Written:     0
  IOs in progress:   0
  Bytes used:        0 B
Replication Status:  Detached
Replica sets on nodes:
  Set:     0
    Node:  prashanth-blr-dev-2 (Pool 1) >>>>> created on node 2
```

```
**Encryption volume**
Prashanths-MacBook-Pro:px prashanthkumar$ ./px create volume encvol --size 1 --encryption
Volume encvol created with id 727694823690630892Prashanths-MacBook-Pro:px prashanthkumar$


[root@prashanth-blr-dev-1 ~]# pxctl v i encvol
Volume  :  727694823690630892
        Name                     :  encvol
        Size                     :  1.0 GiB
        Format                   :  none
        HA                       :  1
        IO Priority              :  LOW
        Creation time            :  Aug 6 11:08:23 UTC 2019
        Shared                   :  no
        Status                   :  up
        State                    :  detached
        Attributes               :  encrypted
        Reads                    :  0
        Reads MS                 :  0
        Bytes Read               :  0
        Writes                   :  0
        Writes MS                :  0
        Bytes Written            :  0
        IOs in progress          :  0
        Bytes used               :  0 B
        Replica sets on nodes:
                Set 0
                  Node           : 70.0.79.18 (Pool 1)
        Replication Status       :  Detached
[root@prashanth-blr-dev-1 ~]#
[ prashanth-blr-dev-1 ][             (0*$root@prashanth-blr-dev-1:~
```