### PR TITLE
Setting default value for the filesystem type as EXT4

### DIFF
--- a/cmd/deleteVolume.go
+++ b/cmd/deleteVolume.go
@@ -61,7 +61,7 @@ func deleteVolumeExec(cmd *cobra.Command, args []string) error {
 		return util.PxErrorMessage(err, "Failed to delete volume")
 	}
 
-	msg := fmt.Sprintf("Volume %s deleted", name)
+	msg := fmt.Sprintf("Volume %s deleted\n", name)
 
 	formattedOut := &util.DefaultFormatOutput{
 		Cmd:  "delete volume",


### PR DESCRIPTION
Part of #18
With out this PR, the Filesystem was passed as FSType_FS_TYPE_NONE and was getting following error, while creating the shared volume:
**Failed to create volume: Failed to create volume: Error in  Volume specification (“testvol4”): Raw block device volume cannot be shared**

**Fix description:**
1) Added --fs flag option with valid values as ('none', 'ext4')
2) request filesystem type will be set based on --fs option value as follow:
--> If --fs='none', request will be set to FSType_FS_TYPE_NONE
--> if --fs='ext4', request will be set to FSType_FS_TYPE_EXT4
--> If --fs is not given, request will be set to FSType_FS_TYPE_EXT4
--> if --fs is invalid valid, return error Error: --fs valid values are [none, ext4]

**Minor fixes:**
1) Made the --replicas flag default value as 1 instead of zero
2) minor message formatting fix.

**Unit Test:**
**case 1: (--fs='none')**
Sivakumars-MacBook-Pro:px siva$ ./px create volume testvol1 --size=2 --fs='none'
Volume testvol1 created with id 801228608289288169
Sivakumars-MacBook-Pro:px siva$ ./px describe volume 801228608289288169 | grep -i 'Format\|HA'
Format:         NONE
HA:             1
Shared:         no

**case 2: (--fs='etx4' --> Invalid)**
Sivakumars-MacBook-Pro:px siva$ ./px create volume testvol2 --size=2 --fs='etx4'
Error: --fs valid values are [none, ext4]

**case 3: (--fs='ext4')**
Sivakumars-MacBook-Pro:px siva$ ./px create volume testvol2 --size=2 --fs='ext4'
Volume testvol2 created with id 1136778392161330099
Sivakumars-MacBook-Pro:px siva$ ./px describe volume 1136778392161330099 | grep -i 'Format\|HA'
Format:         EXT4
HA:             1
Shared:         no

**case 4: (--fs='dummy' --> Invalid)**
Sivakumars-MacBook-Pro:px siva$ ./px create volume testvol3 --size=2 --fs='dummy'
Error: --fs valid values are [none, ext4]

**case 5: (Without --fs flag option)**
Sivakumars-MacBook-Pro:px siva$ ./px create volume testvol3 --size=2
Volume testvol3 created with id 140800009785427556
Sivakumars-MacBook-Pro:px siva$ ./px describe volume 140800009785427556 | grep -i 'Format\|HA'
Format:         EXT4
HA:             1
Shared:         no

**case 6: (--fs='none' and --shared)**
Sivakumars-MacBook-Pro:px siva$ ./px create volume testvol4 --size=2 --fs='none' --shared
Volume testvol4 created with id 764349501844088922
Sivakumars-MacBook-Pro:px siva$ ./px describe volume 764349501844088922 | grep -i 'Format\|HA'
Format:         EXT4
HA:             1
Shared:         yes

**case 7: (--fs='none' and --shared and --replicas=3)**
Sivakumars-MacBook-Pro:px siva$ ./px create volume testvol5 --size=2 --fs='none' --shared --replicas=3
Volume testvol5 created with id 136483392288705081
Sivakumars-MacBook-Pro:px siva$ ./px describe volume 136483392288705081 | grep -i 'Format\|HA'
Format:         EXT4
HA:             3
Shared:         yes
Sivakumars-MacBook-Pro:px siva$

